### PR TITLE
Fix workspace build with cargo-build-sbf v2.3

### DIFF
--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -3,6 +3,6 @@ name = "jiminy-test-utils"
 version.workspace = true
 edition.workspace = true
 
-[dependencies]
+[target.'cfg(not(target_os = "solana"))'.dependencies]
 proptest = { workspace = true }
 solana-logger = { workspace = true }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_os = "solana"))]
 use proptest::{
     prelude::{Just, Strategy},
     strategy::Union,


### PR DESCRIPTION
#### Problem

With https://github.com/anza-xyz/agave/pull/6267, cargo-build-sbf functions like a normal workspace build, in which it tries to build all crates, rather than just those with `cdylib` target. This can cause issues in workspace with crates that don't work for on-chain programs. In this repo, `jiminy-test-utils` is a problematic crate.

#### Summary of changes

Up to you if you want to merge this, but if you want to keep doing workspace builds with `cargo-build-sbf`, then dependencies that don't work on-chain need to be properly gated.

The alternative is to change any scripts to go into individual crates and build them separately, which is also a fine approach.