### PR TITLE
CPI rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,22 +106,6 @@ ProgramError::from_builtin(BuiltInProgramError::InvalidArgument)
 
 ### CPI Overhaul
 
-#### No More "program account not found" errors
-
-How many times have you ran into the `AccountNotFound` error during program development because you forgot to pass in the
-actual program you were invoking as an account to the instruction? jiminy rectifies this by simply requiring you to pass
-in the `AccountHandle` of the program being invoked to CPI calls as part of the `Instr` struct too.
-
-```rust
-/// A CPI instruction
-#[derive(Debug, Clone, Copy)]
-pub struct Instr<'account, 'data, I> {
-    pub prog: AccountHandle<'account>,
-    pub accounts: I,
-    pub data: &'data [u8],
-}
-```
-
 #### Reusable CPI Buffers
 
 The CPI syscall expects inputs in a very specific format. Most of the work of each library's `invoke_signed()` function is in converting program input data
@@ -153,13 +137,7 @@ cpi.invoke_signed(
 
 ## Benchmarks
 
-[Current eisodos benchmark results with `solana v2.2.6`](https://github.com/febo/eisodos/pull/2)
-
-Compared to the most performant existing library (pinocchio), jiminy:
-
-- produces binaries nearly 3x smaller
-- has comparable performance for account deserialization (1 CU more per account deserialized)
-- uses fewer CUs in both CPI benchmarks
+[Current eisodos benchmark results](https://github.com/febo/eisodos)
 
 ## Development
 

--- a/cpi/src/cpi_account_meta.rs
+++ b/cpi/src/cpi_account_meta.rs
@@ -34,4 +34,17 @@ impl CpiAccountMeta {
             is_signer,
         }
     }
+
+    /// Use the permissions of `acc` instead of having it from
+    /// an arg like [`Self::new`]
+    #[inline(always)]
+    pub(crate) fn fwd(acc: *mut Account) -> Self {
+        unsafe {
+            Self {
+                pubkey: Account::key_ptr(acc),
+                is_writable: (*acc).is_writable(),
+                is_signer: (*acc).is_signer(),
+            }
+        }
+    }
 }

--- a/cpi/src/instruction.rs
+++ b/cpi/src/instruction.rs
@@ -1,9 +1,0 @@
-use jiminy_account::AccountHandle;
-
-/// A CPI instruction
-#[derive(Debug, Clone, Copy)]
-pub struct Instr<'account, 'data, I> {
-    pub prog: AccountHandle<'account>,
-    pub accounts: I,
-    pub data: &'data [u8],
-}

--- a/cpi/src/lib.rs
+++ b/cpi/src/lib.rs
@@ -22,10 +22,8 @@ use pda::*;
 
 mod cpi_account;
 mod cpi_account_meta;
-mod instruction;
 
 pub use cpi_account_meta::*;
-pub use instruction::*;
 
 use cpi_account::*;
 
@@ -98,30 +96,6 @@ impl<const MAX_CPI_ACCOUNTS: usize> Cpi<MAX_CPI_ACCOUNTS> {
 
     #[inline]
     pub fn invoke_signed<'account, const MAX_ACCOUNTS: usize>(
-        &mut self,
-        accounts: &mut Accounts<'account, MAX_ACCOUNTS>,
-        Instr {
-            prog: cpi_prog,
-            data: cpi_ix_data,
-            accounts: cpi_accounts,
-        }: Instr<'_, '_, impl IntoIterator<Item = (AccountHandle<'account>, AccountPerms)>>,
-        signers_seeds: &[PdaSigner],
-    ) -> Result<(), ProgramError> {
-        let cpi_prog_id = *accounts.get(cpi_prog).key();
-        self.invoke_signed_raw(
-            accounts,
-            &cpi_prog_id,
-            cpi_ix_data,
-            cpi_accounts,
-            signers_seeds,
-        )
-    }
-
-    /// Same as [`Self::invoke_signed`], but with args exploded instead of
-    /// in an [`Instr`] struct + doesn't require [`AccountHandle`] for program being invoked
-    /// (useful for self CPIs)
-    #[inline]
-    pub fn invoke_signed_raw<'account, const MAX_ACCOUNTS: usize>(
         &mut self,
         accounts: &mut Accounts<'account, MAX_ACCOUNTS>,
         cpi_prog_id: &[u8; 32],

--- a/prog-interface/system/src/instructions/assign.rs
+++ b/prog-interface/system/src/instructions/assign.rs
@@ -1,7 +1,9 @@
 use generic_array_struct::generic_array_struct;
 use jiminy_cpi::{account::AccountHandle, AccountPerms};
 
-use super::{internal_utils::signer_writable_to_perms, Instruction};
+use crate::AccountHandlePerms;
+
+use super::internal_utils::signer_writable_to_perms;
 
 pub const ASSIGN_IX_DISCM: [u8; 4] = [1, 0, 0, 0];
 
@@ -54,15 +56,9 @@ impl AssignIxData {
     }
 }
 
-#[inline]
-pub fn assign_ix<'account, 'data>(
-    system_prog: AccountHandle<'account>,
-    accounts: AssignIxAccounts<'account>,
-    ix_data: &'data AssignIxData,
-) -> Instruction<'account, 'data, ASSIGN_IX_ACCS_LEN> {
-    Instruction {
-        prog: system_prog,
-        data: ix_data.as_buf(),
-        accounts: accounts.0.into_iter().zip(ASSIGN_IX_ACCOUNT_PERMS.0),
+impl<'accounts> AssignIxAccounts<'accounts> {
+    #[inline]
+    pub fn into_account_handle_perms(self) -> AccountHandlePerms<'accounts, ASSIGN_IX_ACCS_LEN> {
+        self.0.into_iter().zip(ASSIGN_IX_ACCOUNT_PERMS.0)
     }
 }

--- a/prog-interface/system/src/instructions/create_account.rs
+++ b/prog-interface/system/src/instructions/create_account.rs
@@ -1,7 +1,7 @@
 use generic_array_struct::generic_array_struct;
 use jiminy_cpi::{account::AccountHandle, AccountPerms};
 
-use super::{internal_utils::signer_writable_to_perms, Instruction};
+use super::{internal_utils::signer_writable_to_perms, AccountHandlePerms};
 
 pub const CREATE_ACCOUNT_IX_DISCM: [u8; 4] = [0; 4];
 
@@ -60,18 +60,11 @@ impl CreateAccountIxData {
     }
 }
 
-#[inline]
-pub fn create_account_ix<'account, 'data>(
-    system_prog: AccountHandle<'account>,
-    accounts: CreateAccountIxAccounts<'account>,
-    ix_data: &'data CreateAccountIxData,
-) -> Instruction<'account, 'data, CREATE_ACCOUNT_IX_ACCS_LEN> {
-    Instruction {
-        prog: system_prog,
-        data: ix_data.as_buf(),
-        accounts: accounts
-            .0
-            .into_iter()
-            .zip(CREATE_ACCOUNT_IX_ACCOUNT_PERMS.0),
+impl<'accounts> CreateAccountIxAccounts<'accounts> {
+    #[inline]
+    pub fn into_account_handle_perms(
+        self,
+    ) -> AccountHandlePerms<'accounts, CREATE_ACCOUNT_IX_ACCS_LEN> {
+        self.0.into_iter().zip(CREATE_ACCOUNT_IX_ACCOUNT_PERMS.0)
     }
 }

--- a/prog-interface/system/src/instructions/mod.rs
+++ b/prog-interface/system/src/instructions/mod.rs
@@ -15,11 +15,7 @@ pub use assign::*;
 pub use create_account::*;
 pub use transfer::*;
 
-pub type Instruction<'account, 'data, const ACCOUNTS: usize> = jiminy_cpi::Instr<
-    'account,
-    'data,
-    Zip<
-        array::IntoIter<AccountHandle<'account>, ACCOUNTS>,
-        array::IntoIter<AccountPerms, ACCOUNTS>,
-    >,
+pub type AccountHandlePerms<'account, const ACCOUNTS: usize> = Zip<
+    array::IntoIter<AccountHandle<'account>, ACCOUNTS>,
+    array::IntoIter<AccountPerms, ACCOUNTS>,
 >;

--- a/prog-interface/system/src/instructions/transfer.rs
+++ b/prog-interface/system/src/instructions/transfer.rs
@@ -1,7 +1,7 @@
 use generic_array_struct::generic_array_struct;
 use jiminy_cpi::{account::AccountHandle, AccountPerms};
 
-use super::{internal_utils::signer_writable_to_perms, Instruction};
+use super::{internal_utils::signer_writable_to_perms, AccountHandlePerms};
 
 pub const TRANSFER_IX_DISCM: [u8; 4] = [2, 0, 0, 0];
 
@@ -55,15 +55,9 @@ impl TransferIxData {
     }
 }
 
-#[inline]
-pub fn transfer_ix<'account, 'data>(
-    system_prog: AccountHandle<'account>,
-    accounts: TransferIxAccounts<'account>,
-    ix_data: &'data TransferIxData,
-) -> Instruction<'account, 'data, TRANSFER_IX_ACCS_LEN> {
-    Instruction {
-        prog: system_prog,
-        data: ix_data.as_buf(),
-        accounts: accounts.0.into_iter().zip(TRANSFER_IX_ACCOUNT_PERMS.0),
+impl<'accounts> TransferIxAccounts<'accounts> {
+    #[inline]
+    pub fn into_account_handle_perms(self) -> AccountHandlePerms<'accounts, TRANSFER_IX_ACCS_LEN> {
+        self.0.into_iter().zip(TRANSFER_IX_ACCOUNT_PERMS.0)
     }
 }

--- a/test-programs/cpi-sys-transfer/src/lib.rs
+++ b/test-programs/cpi-sys-transfer/src/lib.rs
@@ -35,11 +35,11 @@ fn process_ix(
         [transfer_accs.from(), transfer_accs.to()].map(|handle| accounts.get(*handle).lamports());
 
     let sys_prog_key = *accounts.get(sys_prog).key();
-    Cpi::<MAX_CPI_ACCS>::new().invoke_signed(
+    Cpi::<MAX_CPI_ACCS>::new().invoke_signed_fwd(
         accounts,
         &sys_prog_key,
         TransferIxData::new(trf_amt).as_buf(),
-        transfer_accs.into_account_handle_perms(),
+        transfer_accs.0,
         &[],
     )?;
 

--- a/test-programs/cpi-sys-transfer/src/lib.rs
+++ b/test-programs/cpi-sys-transfer/src/lib.rs
@@ -2,7 +2,7 @@
 
 use jiminy_cpi::{program_error::BuiltInProgramError, Cpi};
 use jiminy_entrypoint::program_error::ProgramError;
-use jiminy_system_prog_interface::{transfer_ix, TransferIxAccs, TransferIxData};
+use jiminy_system_prog_interface::{TransferIxAccs, TransferIxData};
 
 pub const MAX_ACCS: usize = 3;
 
@@ -34,9 +34,12 @@ fn process_ix(
     let [from_lamports_bef, to_lamports_bef] =
         [transfer_accs.from(), transfer_accs.to()].map(|handle| accounts.get(*handle).lamports());
 
+    let sys_prog_key = *accounts.get(sys_prog).key();
     Cpi::<MAX_CPI_ACCS>::new().invoke_signed(
         accounts,
-        transfer_ix(sys_prog, transfer_accs, &TransferIxData::new(trf_amt)),
+        &sys_prog_key,
+        TransferIxData::new(trf_amt).as_buf(),
+        transfer_accs.into_account_handle_perms(),
         &[],
     )?;
 

--- a/test-programs/cpi-sys-transfer/tests/test.rs
+++ b/test-programs/cpi-sys-transfer/tests/test.rs
@@ -12,7 +12,7 @@ use solana_pubkey::Pubkey;
 const PROG_NAME: &str = "cpi_sys_transfer";
 const PROG_ID: Pubkey = solana_pubkey::pubkey!("CkebHSWNvZ5w9Q3GTivrEomZZmwWFNqPpzVA9NFZxpg8");
 
-/// CUs: 1321
+/// CUs: 1322
 #[test]
 fn transfer_basic_cus() {
     const TRF_AMT: u64 = 1_000_000_000;


### PR DESCRIPTION
- Delete `Instr` struct, seems like an unnecessary abstraction
  - all inner types of the struct have different types, so no ambiguity even if args to fn were exploded
- CPI program ID is now just a pubkey ref instead of `AccountHandle`
  - makes self-CPI possible without having to pass in currently executing program as an account input
  - comes at the cost of no longer guarding against cases where user forgets to pass in program account to execute for non self CPIs
- introduce `invoke_signed_fwd`, which is the same as `invoke_signed`, but simply forwards the given `Account`'s permissions within the currently executing program's context, instead of taking `AccountPerms` from an external source 