### PR TITLE
`invoke_signed_fwd` -> `invoke_fwd`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,11 @@ fn process_ix(
     };
 
     let sys_prog_key = *accounts.get(sys_prog).key();
-    Cpi::<MAX_CPI_ACCS>::new().invoke_signed_fwd(
+    Cpi::<MAX_CPI_ACCS>::new().invoke_fwd(
         accounts,
         &sys_prog_key,
         TransferIxData::new(trf_amt).as_buf(),
         transfer_accs.0,
-        &[],
     )?;
 
     Ok(())
@@ -116,12 +115,11 @@ memory footprint.
 // required than what is available on the stack.
 let mut cpi: Cpi = Cpi::new();
 
-cpi.invoke_signed_fwd(
+cpi.invoke_fwd(
     accounts,
     &sys_prog_key,
     TransferIxData::new(ONE_SOL_IN_LAMPORTS).as_buf(),
     transfer_accs.0,
-    &[],
 )?;
 
 // use the same allocation again for a completely different CPI

--- a/cpi/src/lib.rs
+++ b/cpi/src/lib.rs
@@ -136,16 +136,19 @@ impl<const MAX_CPI_ACCOUNTS: usize> Cpi<MAX_CPI_ACCOUNTS> {
         }
     }
 
-    /// Same as [`Self::invoke_signed`], but simply forwards the [`AccountPerms`] of the
-    /// account within the `accounts` context instead of relying on another source
+    /// CPI, but unlike [`Self::invoke_signed`], simply forwards the [`AccountPerms`] of each
+    /// account within the `accounts` context instead of relying on another source.
+    ///
+    /// As such, this should not be used with any PDA signers, because a PDA signer should
+    /// have is_signer=false in the invoking program's context, but will need to have
+    /// is_signer set to true when CPI-ing. Use [`Self::invoke_signed`] instead.
     #[inline]
-    pub fn invoke_signed_fwd<'account, const MAX_ACCOUNTS: usize>(
+    pub fn invoke_fwd<'account, const MAX_ACCOUNTS: usize>(
         &mut self,
         accounts: &mut Accounts<'account, MAX_ACCOUNTS>,
         cpi_prog_id: &[u8; 32],
         cpi_ix_data: &[u8],
         cpi_accounts: impl IntoIterator<Item = AccountHandle<'account>>,
-        signers_seeds: &[PdaSigner],
     ) -> Result<(), ProgramError> {
         let len = cpi_accounts.into_iter().try_fold(0, |len, handle| {
             if len >= MAX_CPI_ACCOUNTS {
@@ -169,7 +172,7 @@ impl<const MAX_CPI_ACCOUNTS: usize> Cpi<MAX_CPI_ACCOUNTS> {
                 cpi_ix_data,
                 core::slice::from_raw_parts(self.metas.as_ptr().cast(), len),
                 core::slice::from_raw_parts(self.accounts.as_ptr().cast(), len),
-                signers_seeds,
+                &[],
             )
         }
     }

--- a/test-programs/cpi-sys-transfer/src/lib.rs
+++ b/test-programs/cpi-sys-transfer/src/lib.rs
@@ -35,12 +35,11 @@ fn process_ix(
         [transfer_accs.from(), transfer_accs.to()].map(|handle| accounts.get(*handle).lamports());
 
     let sys_prog_key = *accounts.get(sys_prog).key();
-    Cpi::<MAX_CPI_ACCS>::new().invoke_signed_fwd(
+    Cpi::<MAX_CPI_ACCS>::new().invoke_fwd(
         accounts,
         &sys_prog_key,
         TransferIxData::new(trf_amt).as_buf(),
         transfer_accs.0,
-        &[],
     )?;
 
     if accounts.get(*transfer_accs.from()).lamports() != from_lamports_bef - trf_amt {


### PR DESCRIPTION
See doc comment on `invoke_fwd` method in the diff on why