### PR TITLE
CPI overhaul 3: eletric boogalo

### DIFF
--- a/account/src/lib.rs
+++ b/account/src/lib.rs
@@ -365,7 +365,7 @@ mod tests {
     fn comptime_lifetimes_check() {
         let mut invalid_runtime_buffer = [];
         let (_, invalid_acc) =
-            unsafe { AccountHandle::non_dup_from_ptr(invalid_runtime_buffer.as_mut_ptr()) };
+            unsafe { AccountHandle::non_dup_from_ptr(invalid_runtime_buffer.as_mut_ptr(), &[]) };
         let mut invalid_accounts: Accounts<'_, 1> = Accounts {
             accounts: [MaybeUninit::new(invalid_acc)],
             len: 1,


### PR DESCRIPTION
The `unsafe` stuff was a horrible idea, was permitting usage of temp vars which led to memory corruption bugs.

Figured out how to bound the lifetimes correctly in this PR and removed all `unsafe` usage